### PR TITLE
Unlock and lock packages around package installation

### DIFF
--- a/roles/satellite-receptor/tasks/determine_maintain_command.yml
+++ b/roles/satellite-receptor/tasks/determine_maintain_command.yml
@@ -1,0 +1,11 @@
+- name: Check if {{ item }} can be used for package locking
+  when: maintain_command is not defined
+  block:
+    - name: Check if {{ item }} is installed
+      command: "command -v {{ item }}"
+      register: maintain_test
+      ignore_errors: true
+    - name: Set {{ item }} to be used for package locking
+      set_fact:
+        maintain_command: "{{ item }}"
+      when: maintain_test.rc == 0

--- a/roles/satellite-receptor/tasks/main.yml
+++ b/roles/satellite-receptor/tasks/main.yml
@@ -14,16 +14,27 @@
     - name: Can connect to cloud.redhat.com
       debug:
         msg: "FIXME"
+- name: Determine which command to use for locking packages
+  include_tasks: determine_maintain_command.yml
+  loop:
+    - satellite-maintain
+    - foreman-maintain
 - name: Install Receptor and Satellite Plugin RPMs
   block:
   - name: Ensure RPM repository is configured and enabled
     debug:
       msg: "FIXME"
+  - name: Unlock packages
+    command: "{{ maintain_command }} package unlock"
+    when: maintain_command is defined
   - name: Install Receptor and Satellite Plugin RPMs
     yum:
       name: "{{ receptor_packages }}"
       state: installed
     become: yes
+  - name: Lock packages
+    command: "{{ maintain_command }} package lock"
+    when: maintain_command is defined
 - name: Extract account information from Satellite and write configs
   block:
   - name: List all organizations in Satellite


### PR DESCRIPTION
Satellite locks packages after installation. We need to unlock packages before we can install anything.