### PR TITLE
Add [Install] section to receptor@.service

### DIFF
--- a/templates/receptor@.service.j2
+++ b/templates/receptor@.service.j2
@@ -4,3 +4,6 @@ After=network.target
 
 [Service]
 ExecStart=/usr/bin/receptor -c {{receptor_config_dir}}/%i/receptor.conf -d {{receptor_data_dir}}/%i node
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
When systemd is told to enable or disable a unit, it looks for an
`[Install]` section in that unit's definition to learn how to enable or
disable that unit. If the `[Install]` section is missing, then systemd
doesn't know what to do, and it ignores the enable or disable command.