### PR TITLE
Fix Red Hat account ID jmespath selector

### DIFF
--- a/tasks/extract_orgs.yml
+++ b/tasks/extract_orgs.yml
@@ -23,7 +23,7 @@
   register: sat_org_subscriptions
 - name: Extract Red Hat account ID
   set_fact:
-    sat_account_id: "{{ sat_org_subscriptions.json | json_query('results[0].account_number') }}"
+    sat_account_id: "{{ sat_org_subscriptions.json | json_query('results[?account_number != null] | [0].account_number') }}"
 - name: If an account number is findable
   block:
   - debug:


### PR DESCRIPTION
The role for installing Receptor with Satellite scans for organizations, looks for the first subscription associated with that organization, and extracts the account ID from that first subscription.

If a particular account is only associated with organizations that also have a custom subscription as their first subscription returned by the API, that account will not have a Receptor set up and running for it.

This fixes that behavior.