### PR TITLE
BZ #1849656 - Fix you cannot use loops on 'import_tasks' statements

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,13 +102,10 @@
     set_fact:
       satellite_uuid: "{{ satellite_uuid_json | json_query('json.results[0].value') }}"
   - name: Set up Source with c.rh.c for each account
-    import_tasks: register_with_sources.yml
+    include_tasks: register_with_sources.yml
     loop: "{{ account_dirs }}"
     loop_control:
       loop_var: account_dir
-    environment:
-      http_proxy: "{{ http_proxy }}"
-      https_proxy: "{{ http_proxy }}"
   tags: register_with_sources
 - name: Create Receptor systemd unit files per account and start them
   block:

--- a/tasks/register_with_sources.yml
+++ b/tasks/register_with_sources.yml
@@ -1,98 +1,104 @@
 ---
-- name: Extract node ID from configuration
-  set_fact:
-    receptor_node_id: "{{ lookup('ini', 'node_id section=default file='+receptor_config_dir+'/'+account_dir+'/receptor.conf') }}"
-- name: Identify Satellite source type
-  uri:
-    url: "https://{{ c_rh_c_host }}/api/sources/v2.0/source_types?name=satellite"
-    client_cert: "{{ receptor_config_dir }}/{{ account_dir }}/cert.pem"
-    client_key: "{{ receptor_config_dir }}/{{ account_dir }}/key.pem"
-    return_content: yes
-  register: source_types_response
-- name: Extract Satellite source type from response
-  set_fact:
-    source_type_id: "{{ source_types_response.json | json_query('data[0].id') }}"
-- name: See if source already exists
-  uri:
-    url: "https://{{ c_rh_c_host }}/api/sources/v2.0/sources?source_ref={{ satellite_uuid }}"
-    client_cert: "{{ receptor_config_dir }}/{{ account_dir }}/cert.pem"
-    client_key: "{{ receptor_config_dir }}/{{ account_dir }}/key.pem"
-    return_content: yes
-  register: existing_source_response
-- name: Create Source in c.rh.c
-  uri:
-    url: "https://{{ c_rh_c_host }}/api/sources/v2.0/sources"
-    client_cert: "{{ receptor_config_dir }}/{{ account_dir }}/cert.pem"
-    client_key: "{{ receptor_config_dir }}/{{ account_dir }}/key.pem"
-    method: "POST"
-    body:
-      name: "{{ source_display_name }}"
-      source_type_id: "{{ source_type_id }}"
-      source_ref: "{{ satellite_uuid }}"
-    body_format: json
-    return_content: yes
-    status_code:
-      - 201
-  register: source_create_response
-  when: existing_source_response.json.meta.count == 0
-- name: Set source ID fact (just created)
-  set_fact:
-    source_id: "{{ source_create_response.json.id }}"
-  when: existing_source_response.json.meta.count == 0
-- name: Set source ID fact (pre-existing)
-  set_fact:
-    source_id: "{{ existing_source_response.json | json_query('data[0].id') }}"
-  when: existing_source_response.json.meta.count != 0
-- debug:
-    msg: "Source ID {{ source_id }}"
-- name: See if endpoint already exists
-  uri:
-    url: "https://{{ c_rh_c_host }}/api/sources/v2.0/endpoints?source_id={{ source_id }}"
-    client_cert: "{{ receptor_config_dir }}/{{ account_dir }}/cert.pem"
-    client_key: "{{ receptor_config_dir }}/{{ account_dir }}/key.pem"
-    return_content: yes
-  register: existing_endpoint_response
-- name: Add endpoint to Source
-  uri:
-    url: "https://{{ c_rh_c_host }}/api/sources/v2.0/endpoints"
-    client_cert: "{{ receptor_config_dir }}/{{ account_dir }}/cert.pem"
-    client_key: "{{ receptor_config_dir }}/{{ account_dir }}/key.pem"
-    method: "POST"
-    body:
-      source_id: "{{ source_id }}"
-      receptor_node: "{{ receptor_node_id }}"
-      default: yes
-    body_format: json
-    status_code:
-      - 201
-  when: existing_endpoint_response.json.meta.count == 0
-- name: Identify application type ID
-  uri:
-    url: "https://{{ c_rh_c_host }}/api/sources/v2.0/application_types?name=%2Finsights%2Fplatform%2Ffifi"
-    client_cert: "{{ receptor_config_dir }}/{{ account_dir }}/cert.pem"
-    client_key: "{{ receptor_config_dir }}/{{ account_dir }}/key.pem"
-    return_content: yes
-  register: application_types_response
-- name: Set application type ID fact
-  set_fact:
-    application_type_id: "{{ application_types_response.json | json_query('data[0].id') }}"
-- name: See if application already exists
-  uri:
-    url: "https://{{ c_rh_c_host }}/api/sources/v2.0/applications?source_id={{ source_id }}&application_type_id={{ application_type_id }}"
-    client_cert: "{{ receptor_config_dir }}/{{ account_dir }}/cert.pem"
-    client_key: "{{ receptor_config_dir }}/{{ account_dir }}/key.pem"
-    return_content: yes
-  register: existing_application_response
-- name: Add application to Source
-  uri:
-    url: "https://{{ c_rh_c_host }}/api/sources/v2.0/applications"
-    client_cert: "{{ receptor_config_dir }}/{{ account_dir }}/cert.pem"
-    client_key: "{{ receptor_config_dir }}/{{ account_dir }}/key.pem"
-    method: "POST"
-    body:
-      source_id: "{{ source_id }}"
-      application_type_id: "{{ application_type_id }}"
-    body_format: json
-    status_code:
-      - 201
-  when: existing_application_response.json.meta.count == 0
+- name: Set proxy environment variables
+  environment:
+    http_proxy: "{{ http_proxy }}"
+    https_proxy: "{{ http_proxy }}"
+  block:
+    - name: Extract node ID from configuration
+      set_fact:
+        receptor_node_id: "{{ lookup('ini', 'node_id section=default file='+receptor_config_dir+'/'+account_dir+'/receptor.conf') }}"
+    - name: Identify Satellite source type
+      uri:
+        url: "https://{{ c_rh_c_host }}/api/sources/v2.0/source_types?name=satellite"
+        client_cert: "{{ receptor_config_dir }}/{{ account_dir }}/cert.pem"
+        client_key: "{{ receptor_config_dir }}/{{ account_dir }}/key.pem"
+        return_content: yes
+      register: source_types_response
+    - name: Extract Satellite source type from response
+      set_fact:
+        source_type_id: "{{ source_types_response.json | json_query('data[0].id') }}"
+    - name: See if source already exists
+      uri:
+        url: "https://{{ c_rh_c_host }}/api/sources/v2.0/sources?source_ref={{ satellite_uuid }}"
+        client_cert: "{{ receptor_config_dir }}/{{ account_dir }}/cert.pem"
+        client_key: "{{ receptor_config_dir }}/{{ account_dir }}/key.pem"
+        return_content: yes
+      register: existing_source_response
+    - name: Create Source in c.rh.c
+      uri:
+        url: "https://{{ c_rh_c_host }}/api/sources/v2.0/sources"
+        client_cert: "{{ receptor_config_dir }}/{{ account_dir }}/cert.pem"
+        client_key: "{{ receptor_config_dir }}/{{ account_dir }}/key.pem"
+        method: "POST"
+        body:
+          name: "{{ source_display_name }}"
+          source_type_id: "{{ source_type_id }}"
+          source_ref: "{{ satellite_uuid }}"
+        body_format: json
+        return_content: yes
+        status_code:
+          - 201
+      register: source_create_response
+      when: existing_source_response.json.meta.count == 0
+    - name: Set source ID fact (just created)
+      set_fact:
+        source_id: "{{ source_create_response.json.id }}"
+      when: existing_source_response.json.meta.count == 0
+    - name: Set source ID fact (pre-existing)
+      set_fact:
+        source_id: "{{ existing_source_response.json | json_query('data[0].id') }}"
+      when: existing_source_response.json.meta.count != 0
+    - debug:
+        msg: "Source ID {{ source_id }}"
+    - name: See if endpoint already exists
+      uri:
+        url: "https://{{ c_rh_c_host }}/api/sources/v2.0/endpoints?source_id={{ source_id }}"
+        client_cert: "{{ receptor_config_dir }}/{{ account_dir }}/cert.pem"
+        client_key: "{{ receptor_config_dir }}/{{ account_dir }}/key.pem"
+        return_content: yes
+      register: existing_endpoint_response
+    - name: Add endpoint to Source
+      uri:
+        url: "https://{{ c_rh_c_host }}/api/sources/v2.0/endpoints"
+        client_cert: "{{ receptor_config_dir }}/{{ account_dir }}/cert.pem"
+        client_key: "{{ receptor_config_dir }}/{{ account_dir }}/key.pem"
+        method: "POST"
+        body:
+          source_id: "{{ source_id }}"
+          receptor_node: "{{ receptor_node_id }}"
+          default: yes
+        body_format: json
+        status_code:
+          - 201
+      when: existing_endpoint_response.json.meta.count == 0
+    - name: Identify application type ID
+      uri:
+        url: "https://{{ c_rh_c_host }}/api/sources/v2.0/application_types?name=%2Finsights%2Fplatform%2Ffifi"
+        client_cert: "{{ receptor_config_dir }}/{{ account_dir }}/cert.pem"
+        client_key: "{{ receptor_config_dir }}/{{ account_dir }}/key.pem"
+        return_content: yes
+      register: application_types_response
+    - name: Set application type ID fact
+      set_fact:
+        application_type_id: "{{ application_types_response.json | json_query('data[0].id') }}"
+    - name: See if application already exists
+      uri:
+        url: "https://{{ c_rh_c_host }}/api/sources/v2.0/applications?source_id={{ source_id }}&application_type_id={{ application_type_id }}"
+        client_cert: "{{ receptor_config_dir }}/{{ account_dir }}/cert.pem"
+        client_key: "{{ receptor_config_dir }}/{{ account_dir }}/key.pem"
+        return_content: yes
+      register: existing_application_response
+    - name: Add application to Source
+      uri:
+        url: "https://{{ c_rh_c_host }}/api/sources/v2.0/applications"
+        client_cert: "{{ receptor_config_dir }}/{{ account_dir }}/cert.pem"
+        client_key: "{{ receptor_config_dir }}/{{ account_dir }}/key.pem"
+        method: "POST"
+        body:
+          source_id: "{{ source_id }}"
+          application_type_id: "{{ application_type_id }}"
+        body_format: json
+        status_code:
+          - 201
+      when: existing_application_response.json.meta.count == 0
+


### PR DESCRIPTION
Turns out `import_tasks` imports the tasks before the actual run is
started so it cannot import tasks dynamically based on something
generated during the play. `include_tasks` is the right variant for
this.

The catch with `include_tasks` is that environment cannot be set on this
task, for this reason the contents of `register_with_sources` had to be
wrapped in a block to apply the environment to all tasks in it.