### PR TITLE
BZ #1855710 - Drop FIXME from code

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,9 +33,6 @@
     - foreman-maintain
 - name: Install Receptor and Satellite Plugin RPMs
   block:
-  - name: Ensure RPM repository is configured and enabled
-    debug:
-      msg: "FIXME"
   - name: Unlock packages
     command: "{{ maintain_command }} packages unlock"
     when: maintain_command is defined


### PR DESCRIPTION
The role deploys receptor on a Satellite machine. Since we ship receptor and
receptor-satellite in satellite's repos, we can safely assume both packages are
available.