### PR TITLE
Fix setting HTTPS?_PROXY for receptor

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -106,6 +106,15 @@
   tags: register_with_sources
 - name: Create Receptor systemd unit files per account and start them
   block:
+  - name: Genereate environment files
+    copy:
+      dest: "{{ receptor_config_dir }}/{{ account_dir }}/receptor.env"
+      content: |
+        HTTP_PROXY={{ http_proxy }}
+        HTTPS_PROXY={{ http_proxy }}
+    loop: "{{ account_dirs }}"
+    loop_control:
+      loop_var: account_dir
   - name: Generate template unit file
     template:
       src: receptor@.service.j2

--- a/templates/receptor@.service.j2
+++ b/templates/receptor@.service.j2
@@ -4,8 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=/usr/bin/receptor -c {{receptor_config_dir}}/%i/receptor.conf -d {{receptor_data_dir}}/%i node
-Environment=HTTP_PROXY="{{ http_proxy }}"
-Environment=HTTPS_PROXY="{{ http_proxy }}"
+EnvironmentFile=-{{ receptor_config_dir }}/%i/receptor.env
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This change also introduced per-receptor-instance environment files instead of
setting the proxy directly in the template systemd unit.