### PR TITLE
BZ #1868971 - Escape passwords containing a percent sign

### DIFF
--- a/templates/receptor.conf.j2
+++ b/templates/receptor.conf.j2
@@ -2,14 +2,14 @@
 node_id={{ lookup('file', receptor_config_dir+'/rh_'+sat_account_id+'/uuid') }}
 
 [plugin_receptor_satellite]
-username={{ satellite_user }}
-password={{ satellite_password }}
+username={{ satellite_user | regex_replace('%', '%%') }}
+password={{ satellite_password | regex_replace('%', '%%') }}
 url={{ satellite_url }}
-ca_file={{ satellite_ca_file }}
+ca_file={{ satellite_ca_file | regex_replace('%', '%%') }}
 
 [auth]
-client_cert={{ receptor_config_dir }}/rh_{{ sat_account_id }}/cert.pem
-client_key={{ receptor_config_dir }}/rh_{{ sat_account_id }}/key.pem
+client_cert={{ receptor_config_dir | regex_replace('%', '%%') }}/rh_{{ sat_account_id }}/cert.pem
+client_key={{ receptor_config_dir | regex_replace('%', '%%') }}/rh_{{ sat_account_id }}/key.pem
 
 [node]
 peers=wss://{{ c_rh_c_host }}/wss/receptor-controller/gateway

--- a/templates/receptor@.service.j2
+++ b/templates/receptor@.service.j2
@@ -3,8 +3,8 @@ Description=Receptor Node for %i
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/receptor -c {{receptor_config_dir}}/%i/receptor.conf -d {{receptor_data_dir}}/%i node
-EnvironmentFile=-{{ receptor_config_dir }}/%i/receptor.env
+ExecStart=/usr/bin/receptor -c {{ receptor_config_dir | regex_replace('%', '%%') }}/%i/receptor.conf -d {{ receptor_data_dir | regex_replace('%', '%%') }}/%i node
+EnvironmentFile=-{{ receptor_config_dir | regex_replace('%', '%%') }}/%i/receptor.env
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Python's ConfigParser[1] introduces some non-standard syntax for referencing
other parts of the ini file. Unless a % sign is escaped with another %, the
parser will crash, emitting the "unreadable" value into the logs.

[1] - https://docs.python.org/3/library/configparser.html#configparser.BasicInterpolation