### PR TITLE
Add variable to allow disabling cloud connector

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,4 @@ skip_satellite_org_id_list:
   - 0
 source_display_name: "{{ satellite_url|urlsplit('hostname') }}"
 http_proxy: ""
+cloud_connector_enabled: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -121,8 +121,8 @@
   - name: Enable Receptor systemd units
     systemd:
       unit: "receptor@{{ item }}.service"
-      enabled: yes
-      state: started
+      enabled: "{{ cloud_connector_enabled }}"
+      state: "{{ cloud_connector_enabled | ternary('started', 'stopped') }}"
     loop: "{{ account_dirs }}"
   tags: install_into_systemd
   become: yes


### PR DESCRIPTION
This is untested and does this for all accounts. I think supporting this per account is a lot more work. @ares thoughts?